### PR TITLE
LPS-110945 Delete the structure created when executing the test

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/test/DDMStructureManagerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/test/DDMStructureManagerTest.java
@@ -24,6 +24,8 @@ import com.liferay.dynamic.data.mapping.kernel.DDMStructureManager;
 import com.liferay.dynamic.data.mapping.kernel.LocalizedValue;
 import com.liferay.dynamic.data.mapping.kernel.StorageEngineManager;
 import com.liferay.dynamic.data.mapping.kernel.Value;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.model.Group;
@@ -42,10 +44,12 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -69,6 +73,19 @@ public class DDMStructureManagerTest {
 	public static void setUpClass() {
 		_classNameId = _portal.getClassNameId(
 			"com.liferay.dynamic.data.mapping.model.DDMFormInstance");
+
+		_ddmStructureIds = new ArrayList<>();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		DB db = DBManagerUtil.getDB();
+
+		for (Long ddmStructureId : _ddmStructureIds) {
+			db.runSQL(
+				"delete from DDMStructure where structureId = " +
+					ddmStructureId);
+		}
 	}
 
 	@Before
@@ -317,11 +334,15 @@ public class DDMStructureManagerTest {
 			LocaleUtil.US, "Test Structure Description"
 		).build();
 
-		return _ddmStructureManager.addStructure(
+		DDMStructure structure = _ddmStructureManager.addStructure(
 			TestPropsValues.getUserId(), _group.getGroupId(), null,
 			_classNameId, StringUtil.randomString(), nameMap, descriptionMap,
 			createDDMForm(), StorageEngineManager.STORAGE_TYPE_DEFAULT,
 			DDMStructureManager.STRUCTURE_TYPE_DEFAULT, _serviceContext);
+
+		_ddmStructureIds.add(structure.getStructureId());
+
+		return structure;
 	}
 
 	protected void assertEquals(
@@ -381,6 +402,7 @@ public class DDMStructureManagerTest {
 	}
 
 	private static long _classNameId;
+	private static List<Long> _ddmStructureIds;
 
 	@Inject
 	private static DDMStructureManager _ddmStructureManager;


### PR DESCRIPTION
As mentioned in the commit, to perform this solution it’s not possible to use `@DeleteAfterTestRun` because the class `com.liferay.dynamic.data.mapping.kernel.DDMStructure` doesn’t extend the `PersistedModel` class.
Besides, in some tests (like `testGetClassStructures`, `testGetClassStructuresUsingComparator`, `testGetClassStructuresWithCompanyAndClassNameId`) there is a specific order to call the `addStructure()` function. For this reason, it is not possible to make the call in the `setUp()` method, as is done in `addGroup()`.