### PR TITLE
LPS-118440

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueAccessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueAccessor.java
@@ -15,6 +15,9 @@
 package com.liferay.dynamic.data.mapping.form.field.type.internal.checkbox.multiple;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueAccessor;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.petra.string.CharPool;
@@ -25,10 +28,13 @@ import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Locale;
 import java.util.function.IntFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -55,13 +61,24 @@ public class CheckboxMultipleDDMFormFieldValueAccessor
 	public JSONArray getValue(
 		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
 
-		Value value = ddmFormFieldValue.getValue();
+		JSONArray optionsValuesJSONArray = getOptionsValuesJSONArray(
+			ddmFormFieldValue, locale);
 
-		if (value == null) {
-			return createJSONArray("[]");
+		Matcher matcher = _pattern.matcher(optionsValuesJSONArray.getString(0));
+
+		if (!matcher.matches() ||
+			(ddmFormFieldValue.getDDMFormValues() == null)) {
+
+			return optionsValuesJSONArray;
 		}
 
-		return createJSONArray(value.getString(locale));
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(StringPool.OPEN_BRACKET);
+		sb.append(getOptionsLabels(ddmFormFieldValue, locale));
+		sb.append(StringPool.CLOSE_BRACKET);
+
+		return createJSONArray(sb.toString());
 	}
 
 	@Override
@@ -118,10 +135,72 @@ public class CheckboxMultipleDDMFormFieldValueAccessor
 		}
 	}
 
+	protected DDMFormFieldOptions getDDMFormFieldOptions(
+		DDMFormFieldValue ddmFormFieldValue) {
+
+		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
+
+		return ddmFormField.getDDMFormFieldOptions();
+	}
+
+	protected String getOptionsLabels(
+		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
+
+		JSONArray optionsValuesJSONArray = getOptionsValuesJSONArray(
+			ddmFormFieldValue, locale);
+
+		if (optionsValuesJSONArray.length() == 0) {
+			return StringPool.BLANK;
+		}
+
+		DDMFormFieldOptions ddmFormFieldOptions = getDDMFormFieldOptions(
+			ddmFormFieldValue);
+
+		StringBundler sb = new StringBundler(
+			(optionsValuesJSONArray.length() * 2) - 1);
+
+		for (int i = 0; i < optionsValuesJSONArray.length(); i++) {
+			String optionValue = optionsValuesJSONArray.getString(i);
+
+			LocalizedValue optionLabel = ddmFormFieldOptions.getOptionLabels(
+				optionValue);
+
+			if (optionLabel != null) {
+				sb.append(HtmlUtil.escape(optionLabel.getString(locale)));
+			}
+			else {
+				sb.append(optionValue);
+			}
+
+			sb.append(StringPool.COMMA_AND_SPACE);
+		}
+
+		if (sb.index() > 0) {
+			sb.setIndex(sb.index() - 1);
+		}
+
+		return sb.toString();
+	}
+
+	protected JSONArray getOptionsValuesJSONArray(
+		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
+
+		Value value = ddmFormFieldValue.getValue();
+
+		if (value == null) {
+			return createJSONArray("[]");
+		}
+
+		return createJSONArray(value.getString(locale));
+	}
+
 	@Reference
 	protected JSONFactory jsonFactory;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CheckboxMultipleDDMFormFieldValueAccessor.class);
+
+	private static final Pattern _pattern = Pattern.compile(
+		"^[A-Za-z]*[0-9]{8}$");
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRenderer.java
@@ -15,14 +15,7 @@
 package com.liferay.dynamic.data.mapping.form.field.type.internal.checkbox.multiple;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRenderer;
-import com.liferay.dynamic.data.mapping.model.DDMFormField;
-import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
-import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Locale;
 
@@ -41,44 +34,8 @@ public class CheckboxMultipleDDMFormFieldValueRenderer
 
 	@Override
 	public String render(DDMFormFieldValue ddmFormFieldValue, Locale locale) {
-		JSONArray optionsValuesJSONArray =
-			checkboxMultipleDDMFormFieldValueAccessor.getValue(
-				ddmFormFieldValue, locale);
-
-		if (optionsValuesJSONArray.length() == 0) {
-			return StringPool.BLANK;
-		}
-
-		DDMFormFieldOptions ddmFormFieldOptions = getDDMFormFieldOptions(
-			ddmFormFieldValue);
-
-		StringBundler sb = new StringBundler(
-			(optionsValuesJSONArray.length() * 2) - 1);
-
-		for (int i = 0; i < optionsValuesJSONArray.length(); i++) {
-			LocalizedValue optionLabel = ddmFormFieldOptions.getOptionLabels(
-				optionsValuesJSONArray.getString(i));
-
-			if (optionLabel != null) {
-				sb.append(HtmlUtil.escape(optionLabel.getString(locale)));
-
-				sb.append(StringPool.COMMA_AND_SPACE);
-			}
-		}
-
-		if (sb.index() > 0) {
-			sb.setIndex(sb.index() - 1);
-		}
-
-		return sb.toString();
-	}
-
-	protected DDMFormFieldOptions getDDMFormFieldOptions(
-		DDMFormFieldValue ddmFormFieldValue) {
-
-		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
-
-		return ddmFormField.getDDMFormFieldOptions();
+		return checkboxMultipleDDMFormFieldValueAccessor.getOptionsLabels(
+			ddmFormFieldValue, locale);
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueAccessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueAccessor.java
@@ -15,11 +15,17 @@
 package com.liferay.dynamic.data.mapping.form.field.type.internal.radio;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueAccessor;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Locale;
 import java.util.function.IntFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -42,9 +48,54 @@ public class RadioDDMFormFieldValueAccessor
 
 	@Override
 	public String getValue(DDMFormFieldValue ddmFormFieldValue, Locale locale) {
+		String optionValue = getOptionValue(ddmFormFieldValue, locale);
+
+		Matcher matcher = _pattern.matcher(optionValue);
+
+		if (!matcher.matches() ||
+			(ddmFormFieldValue.getDDMFormValues() == null)) {
+
+			return optionValue;
+		}
+
+		return getOptionLabel(ddmFormFieldValue, locale);
+	}
+
+	protected DDMFormFieldOptions getDDMFormFieldOptions(
+		DDMFormFieldValue ddmFormFieldValue) {
+
+		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
+
+		return ddmFormField.getDDMFormFieldOptions();
+	}
+
+	protected String getOptionLabel(
+		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
+
+		String optionValue = getOptionValue(ddmFormFieldValue, locale);
+
+		DDMFormFieldOptions ddmFormFieldOptions = getDDMFormFieldOptions(
+			ddmFormFieldValue);
+
+		LocalizedValue optionLabel = ddmFormFieldOptions.getOptionLabels(
+			optionValue);
+
+		if (optionLabel == null) {
+			return optionValue;
+		}
+
+		return HtmlUtil.escape(optionLabel.getString(locale));
+	}
+
+	protected String getOptionValue(
+		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
+
 		Value value = ddmFormFieldValue.getValue();
 
 		return value.getString(locale);
 	}
+
+	private static final Pattern _pattern = Pattern.compile(
+		"^[A-Za-z]*[0-9]{8}$");
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueRenderer.java
@@ -15,12 +15,7 @@
 package com.liferay.dynamic.data.mapping.form.field.type.internal.radio;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRenderer;
-import com.liferay.dynamic.data.mapping.model.DDMFormField;
-import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
-import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Locale;
 
@@ -39,28 +34,8 @@ public class RadioDDMFormFieldValueRenderer
 
 	@Override
 	public String render(DDMFormFieldValue ddmFormFieldValue, Locale locale) {
-		String optionValue = radioDDMFormFieldValueAccessor.getValue(
+		return radioDDMFormFieldValueAccessor.getOptionLabel(
 			ddmFormFieldValue, locale);
-
-		DDMFormFieldOptions ddmFormFieldOptions = getDDMFormFieldOptions(
-			ddmFormFieldValue);
-
-		LocalizedValue optionLabel = ddmFormFieldOptions.getOptionLabels(
-			optionValue);
-
-		if (optionLabel == null) {
-			return StringPool.BLANK;
-		}
-
-		return HtmlUtil.escape(optionLabel.getString(locale));
-	}
-
-	protected DDMFormFieldOptions getDDMFormFieldOptions(
-		DDMFormFieldValue ddmFormFieldValue) {
-
-		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
-
-		return ddmFormField.getDDMFormFieldOptions();
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueAccessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueAccessor.java
@@ -15,6 +15,9 @@
 package com.liferay.dynamic.data.mapping.form.field.type.internal.select;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueAccessor;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.petra.string.CharPool;
@@ -25,10 +28,14 @@ import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.function.IntFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -54,13 +61,24 @@ public class SelectDDMFormFieldValueAccessor
 	public JSONArray getValue(
 		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
 
-		Value value = ddmFormFieldValue.getValue();
+		JSONArray optionsValuesJSONArray = getOptionsValuesJSONArray(
+			ddmFormFieldValue, locale);
 
-		if (value == null) {
-			return createJSONArray("[]");
+		Matcher matcher = _pattern.matcher(optionsValuesJSONArray.getString(0));
+
+		if (!matcher.matches() ||
+			(ddmFormFieldValue.getDDMFormValues() == null)) {
+
+			return optionsValuesJSONArray;
 		}
 
-		return createJSONArray(value.getString(locale));
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(StringPool.OPEN_BRACKET);
+		sb.append(getOptionsLabels(ddmFormFieldValue, locale));
+		sb.append(StringPool.CLOSE_BRACKET);
+
+		return createJSONArray(sb.toString());
 	}
 
 	@Override
@@ -115,10 +133,83 @@ public class SelectDDMFormFieldValueAccessor
 		}
 	}
 
+	protected DDMFormFieldOptions getDDMFormFieldOptions(
+		DDMFormFieldValue ddmFormFieldValue) {
+
+		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
+
+		return ddmFormField.getDDMFormFieldOptions();
+	}
+
+	protected String getOptionsLabels(
+		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
+
+		JSONArray optionsValuesJSONArray = getOptionsValuesJSONArray(
+			ddmFormFieldValue, locale);
+
+		if (optionsValuesJSONArray.length() == 0) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler sb = new StringBundler(
+			(optionsValuesJSONArray.length() * 2) - 1);
+
+		DDMFormFieldOptions ddmFormFieldOptions = getDDMFormFieldOptions(
+			ddmFormFieldValue);
+
+		for (int i = 0; i < optionsValuesJSONArray.length(); i++) {
+			String optionValue = optionsValuesJSONArray.getString(i);
+
+			if (isManualDataSourceType(ddmFormFieldValue.getDDMFormField())) {
+				LocalizedValue optionLabel =
+					ddmFormFieldOptions.getOptionLabels(optionValue);
+
+				if (optionLabel != null) {
+					sb.append(HtmlUtil.escape(optionLabel.getString(locale)));
+				}
+				else {
+					sb.append(optionValue);
+				}
+			}
+			else {
+				sb.append(optionValue);
+			}
+
+			sb.append(StringPool.COMMA_AND_SPACE);
+		}
+
+		sb.setIndex(sb.index() - 1);
+
+		return sb.toString();
+	}
+
+	protected JSONArray getOptionsValuesJSONArray(
+		DDMFormFieldValue ddmFormFieldValue, Locale locale) {
+
+		Value value = ddmFormFieldValue.getValue();
+
+		if (value == null) {
+			return createJSONArray("[]");
+		}
+
+		return createJSONArray(value.getString(locale));
+	}
+
+	protected boolean isManualDataSourceType(DDMFormField ddmFormField) {
+		if (Objects.equals(ddmFormField.getDataSourceType(), "manual")) {
+			return true;
+		}
+
+		return false;
+	}
+
 	@Reference
 	protected JSONFactory jsonFactory;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SelectDDMFormFieldValueAccessor.class);
+
+	private static final Pattern _pattern = Pattern.compile(
+		"^[A-Za-z]*[0-9]{8}$");
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRenderer.java
@@ -15,17 +15,9 @@
 package com.liferay.dynamic.data.mapping.form.field.type.internal.select;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRenderer;
-import com.liferay.dynamic.data.mapping.model.DDMFormField;
-import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
-import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Locale;
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,59 +34,8 @@ public class SelectDDMFormFieldValueRenderer
 
 	@Override
 	public String render(DDMFormFieldValue ddmFormFieldValue, Locale locale) {
-		JSONArray optionsValuesJSONArray =
-			selectDDMFormFieldValueAccessor.getValue(ddmFormFieldValue, locale);
-
-		if (optionsValuesJSONArray.length() == 0) {
-			return StringPool.BLANK;
-		}
-
-		DDMFormFieldOptions ddmFormFieldOptions = getDDMFormFieldOptions(
-			ddmFormFieldValue);
-
-		StringBundler sb = new StringBundler(
-			(optionsValuesJSONArray.length() * 2) - 1);
-
-		for (int i = 0; i < optionsValuesJSONArray.length(); i++) {
-			String optionValue = optionsValuesJSONArray.getString(i);
-
-			if (isManualDataSourceType(ddmFormFieldValue.getDDMFormField())) {
-				LocalizedValue optionLabel =
-					ddmFormFieldOptions.getOptionLabels(optionValue);
-
-				if (optionLabel != null) {
-					sb.append(HtmlUtil.escape(optionLabel.getString(locale)));
-				}
-				else {
-					sb.append(optionValue);
-				}
-			}
-			else {
-				sb.append(optionValue);
-			}
-
-			sb.append(StringPool.COMMA_AND_SPACE);
-		}
-
-		sb.setIndex(sb.index() - 1);
-
-		return sb.toString();
-	}
-
-	protected DDMFormFieldOptions getDDMFormFieldOptions(
-		DDMFormFieldValue ddmFormFieldValue) {
-
-		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
-
-		return ddmFormField.getDDMFormFieldOptions();
-	}
-
-	protected boolean isManualDataSourceType(DDMFormField ddmFormField) {
-		if (Objects.equals(ddmFormField.getDataSourceType(), "manual")) {
-			return true;
-		}
-
-		return false;
+		return selectDDMFormFieldValueAccessor.getOptionsLabels(
+			ddmFormFieldValue, locale);
 	}
 
 	@Reference


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-118440

For fields that have options (`Select from List`, `Single Selection` and `Multiple Selection`), the `option ID` is used for validations.

As the generation of the `option ID` is no longer linked to the `option label`, the problem described in this issue is happening.

The proposed solution checks whether the `option ID` matches the `auto-generated ID` pattern and, if it matches, returns the label.

It is not possible to return the label for all cases because, for example, in `TextDDMFormFieldTypeSettings.java` there is a rule with the condition `not (equals (getValue('displayStyle'), 'singleline'))`. In this case `getValue ('displayStyle')` needs to return the `option ID`, since it is not possible to pass the label in place of `'singleline'` (considering that there will be translations).