### PR TITLE
LPS-130688 Align the confirmation field when the label is empty and the direction is Horizontal

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/withConfirmationField.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/withConfirmationField.es.js
@@ -18,6 +18,22 @@ const getClassNameBasedOnDirection = (direction) => {
 	return direction?.includes('horizontal') ? 'col-md-6' : 'col-md-12';
 };
 
+const getConfirmationLabel = (confirmationLabel, label) => {
+	if (confirmationLabel && label) {
+		return [confirmationLabel, label].join(' ');
+	}
+
+	return confirmationLabel || label;
+};
+
+const getLabel = (confirmationLabel, label) => {
+	if (confirmationLabel && !label) {
+		return ' ';
+	}
+
+	return label;
+};
+
 export default (Component) => {
 	const Wrapper = ({requireConfirmation, ...otherProps}) => {
 		if (!requireConfirmation) {
@@ -43,14 +59,17 @@ export default (Component) => {
 		return (
 			<div className="row">
 				<div className={className}>
-					<Component {...otherProps} />
+					<Component
+						{...otherProps}
+						label={getLabel(confirmationLabel, label)}
+					/>
 				</div>
 				<div className={className}>
 					<Component
 						{...otherProps}
 						errorMessage={confirmationErrorMessage}
 						id={`${name}confirmationField`}
-						label={[confirmationLabel, label].join(' ')}
+						label={getConfirmationLabel(confirmationLabel, label)}
 						localizable={false}
 						localizedValue={{}}
 						name={`${name}confirmationField`}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-130688