### PR TITLE
LPS-135713 Predefined Value must come first in case the field is being edited in the Form Builder. In User View, the predefinedValue is always empty

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -46,7 +46,7 @@ const RichText = ({
 		}
 	}, [editingLanguageId, editorRef]);
 
-	const currentValue = value ?? predefinedValue;
+	const currentValue = predefinedValue || value;
 
 	return (
 		<FieldBase


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-135713