### PR TITLE
LPS-137099

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -610,7 +610,8 @@ public class DDMFormDisplayContext {
 	public boolean isSharedURL() {
 		ThemeDisplay themeDisplay = getThemeDisplay();
 
-		return StringUtil.contains(themeDisplay.getURLCurrent(), "/shared");
+		return StringUtil.contains(
+			themeDisplay.getURLCurrent(), "shared", StringPool.FORWARD_SLASH);
 	}
 
 	public boolean isShowConfigurationIcon() throws PortalException {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -411,6 +411,28 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 	}
 
 	@Test
+	public void testIsSharedURL() throws Exception {
+		DDMFormDisplayContext ddmFormDisplayContext = spy(
+			_createDDMFormDisplayContext());
+
+		ThemeDisplay themeDisplay = mock(ThemeDisplay.class);
+
+		when(
+			themeDisplay.getURLCurrent()
+		).thenReturn(
+			"http://localhost:8080/web/forms/shared/-/form/123"
+		);
+
+		Mockito.doReturn(
+			themeDisplay
+		).when(
+			ddmFormDisplayContext
+		).getThemeDisplay();
+
+		Assert.assertTrue(ddmFormDisplayContext.isSharedURL());
+	}
+
+	@Test
 	public void testIsShowIconInEditMode() throws Exception {
 		_mockHttpServletRequest.addParameter("p_l_mode", Constants.EDIT);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -104,20 +104,20 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Before
 	public void setUp() throws PortalException {
-		setUpJSONFactoryUtil();
-		setUpLanguageUtil();
-		setUpLocaleUtil();
-		setUpPortalUtil();
-		setUpResourceBundleUtil();
+		_setUpJSONFactoryUtil();
+		_setUpLanguageUtil();
+		_setUpLocaleUtil();
+		_setUpPortalUtil();
+		_setUpResourceBundleUtil();
 	}
 
 	@Test
 	public void testAutosaveWithDefaultUser() throws Exception {
-		MockRenderRequest renderRequest = mockRenderRequest();
+		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
 		ThemeDisplay themeDisplay = mock(ThemeDisplay.class);
 
-		renderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+		mockRenderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
 		PortletDisplay portletDisplay = mock(PortletDisplay.class);
 
@@ -148,7 +148,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(renderRequest);
+			_createDDMFormDisplayContext(mockRenderRequest);
 
 		Assert.assertEquals(false, ddmFormDisplayContext.isAutosaveEnabled());
 	}
@@ -156,10 +156,10 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 	@Test
 	public void testAutosaveWithNondefaultUser1() throws Exception {
 		RenderRequest renderRequest =
-			mockRenderRequestAutosaveWithNondefaultUser();
+			_mockRenderRequestAutosaveWithNondefaultUser();
 
 		DDMFormInstanceSettings ddmFormInstanceSettings =
-			mockDDMFormInstanceSettingsAutosaveWithNondefaultUser();
+			_mockDDMFormInstanceSettingsAutosaveWithNondefaultUser();
 
 		when(
 			ddmFormInstanceSettings.autosaveEnabled()
@@ -168,7 +168,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(renderRequest);
+			_createDDMFormDisplayContext(renderRequest);
 
 		Assert.assertEquals(false, ddmFormDisplayContext.isAutosaveEnabled());
 	}
@@ -176,10 +176,10 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 	@Test
 	public void testAutosaveWithNondefaultUser2() throws Exception {
 		RenderRequest renderRequest =
-			mockRenderRequestAutosaveWithNondefaultUser();
+			_mockRenderRequestAutosaveWithNondefaultUser();
 
 		DDMFormInstanceSettings ddmFormInstanceSettings =
-			mockDDMFormInstanceSettingsAutosaveWithNondefaultUser();
+			_mockDDMFormInstanceSettingsAutosaveWithNondefaultUser();
 
 		when(
 			ddmFormInstanceSettings.autosaveEnabled()
@@ -194,7 +194,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(renderRequest);
+			_createDDMFormDisplayContext(renderRequest);
 
 		Assert.assertEquals(true, ddmFormDisplayContext.isAutosaveEnabled());
 	}
@@ -202,10 +202,10 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 	@Test
 	public void testAutosaveWithNondefaultUser3() throws Exception {
 		RenderRequest renderRequest =
-			mockRenderRequestAutosaveWithNondefaultUser();
+			_mockRenderRequestAutosaveWithNondefaultUser();
 
 		DDMFormInstanceSettings ddmFormInstanceSettings =
-			mockDDMFormInstanceSettingsAutosaveWithNondefaultUser();
+			_mockDDMFormInstanceSettingsAutosaveWithNondefaultUser();
 
 		when(
 			ddmFormInstanceSettings.autosaveEnabled()
@@ -220,7 +220,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(renderRequest);
+			_createDDMFormDisplayContext(renderRequest);
 
 		Assert.assertEquals(false, ddmFormDisplayContext.isAutosaveEnabled());
 	}
@@ -230,7 +230,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		throws Exception {
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext();
+			_createDDMFormDisplayContext();
 
 		Locale defaultLocale = LocaleUtil.BRAZIL;
 
@@ -239,7 +239,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		availableLocales.add(defaultLocale);
 		availableLocales.add(LocaleUtil.SPAIN);
 
-		DDMForm ddmForm = createDDMForm(availableLocales, defaultLocale);
+		DDMForm ddmForm = _createDDMForm(availableLocales, defaultLocale);
 
 		_request.addParameter(
 			"languageId", LocaleUtil.toLanguageId(LocaleUtil.SPAIN));
@@ -256,7 +256,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		DDMFormInstanceSettings ddmFormInstanceSettings = mock(
 			DDMFormInstanceSettings.class);
 
-		mockDDMFormInstance(ddmFormInstanceSettings);
+		_mockDDMFormInstance(ddmFormInstanceSettings);
 
 		String submitLabel = "Enviar Personalizado";
 
@@ -269,7 +269,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(mockRenderRequest());
+			_createDDMFormDisplayContext(_mockRenderRequest());
 
 		Assert.assertEquals(
 			submitLabel, ddmFormDisplayContext.getSubmitLabel());
@@ -278,7 +278,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 	@Test
 	public void testGetLocale() throws PortalException {
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext();
+			_createDDMFormDisplayContext();
 
 		HttpServletRequest httpServletRequest = Mockito.mock(
 			HttpServletRequest.class);
@@ -292,7 +292,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		Locale defaultLocale = LocaleUtil.US;
 		Locale expectedLocale = LocaleUtil.BRAZIL;
 
-		DDMForm ddmForm = createDDMForm(
+		DDMForm ddmForm = _createDDMForm(
 			new HashSet<>(Arrays.asList(defaultLocale, expectedLocale)),
 			defaultLocale);
 
@@ -303,16 +303,16 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Test
 	public void testGetSubmitLabel() throws Exception {
-		mockDDMFormInstance(mock(DDMFormInstanceSettings.class));
+		_mockDDMFormInstance(mock(DDMFormInstanceSettings.class));
 
 		String submitLabel = "Submit";
 
-		mockLanguageGet("submit-form", submitLabel);
+		_mockLanguageGet("submit-form", submitLabel);
 
-		mockWorkflowDefinitionLinkLocalService(false);
+		_mockWorkflowDefinitionLinkLocalService(false);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(mockRenderRequest());
+			_createDDMFormDisplayContext(_mockRenderRequest());
 
 		Assert.assertEquals(
 			submitLabel, ddmFormDisplayContext.getSubmitLabel());
@@ -320,16 +320,16 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Test
 	public void testGetSubmitLabelWithWorkflow() throws Exception {
-		mockDDMFormInstance(mock(DDMFormInstanceSettings.class));
+		_mockDDMFormInstance(mock(DDMFormInstanceSettings.class));
 
 		String submitLabel = "Submit For Publication";
 
-		mockLanguageGet("submit-for-publication", submitLabel);
+		_mockLanguageGet("submit-for-publication", submitLabel);
 
-		mockWorkflowDefinitionLinkLocalService(true);
+		_mockWorkflowDefinitionLinkLocalService(true);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(mockRenderRequest());
+			_createDDMFormDisplayContext(_mockRenderRequest());
 
 		Assert.assertEquals(
 			submitLabel, ddmFormDisplayContext.getSubmitLabel());
@@ -337,7 +337,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Test
 	public void testIsFormAvailableForGuest() throws Exception {
-		DDMFormInstance ddmFormInstance = mockDDMFormInstance();
+		DDMFormInstance ddmFormInstance = _mockDDMFormInstance();
 
 		when(
 			_ddmFormInstanceLocalService.fetchFormInstance(Matchers.anyLong())
@@ -352,14 +352,14 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext();
+			_createDDMFormDisplayContext();
 
 		Assert.assertFalse(ddmFormDisplayContext.isFormAvailable());
 	}
 
 	@Test
 	public void testIsFormAvailableForLoggedUser() throws Exception {
-		DDMFormInstance ddmFormInstance = mockDDMFormInstance();
+		DDMFormInstance ddmFormInstance = _mockDDMFormInstance();
 
 		when(
 			_ddmFormInstanceLocalService.fetchFormInstance(Matchers.anyLong())
@@ -374,37 +374,38 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext();
+			_createDDMFormDisplayContext();
 
 		Assert.assertTrue(ddmFormDisplayContext.isFormAvailable());
 	}
 
 	@Test
 	public void testIsSharedFormWithoutPortletSession() throws Exception {
-		MockRenderRequest renderRequest = mockRenderRequest();
+		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
-		Assert.assertNull(renderRequest.getPortletSession(false));
+		Assert.assertNull(mockRenderRequest.getPortletSession(false));
 
-		renderRequest.setParameter("shared", Boolean.TRUE.toString());
+		mockRenderRequest.setParameter("shared", Boolean.TRUE.toString());
 
 		DDMFormDisplayContext createDDMFormDisplayContext =
-			createDDMFormDisplayContext(renderRequest);
+			_createDDMFormDisplayContext(mockRenderRequest);
 
 		Assert.assertTrue(createDDMFormDisplayContext.isFormShared());
 	}
 
 	@Test
 	public void testIsSharedFormWithPortletSession() throws Exception {
-		MockRenderRequest renderRequest = mockRenderRequest();
+		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
-		PortletSession portletSession = renderRequest.getPortletSession(true);
+		PortletSession portletSession = mockRenderRequest.getPortletSession(
+			true);
 
 		Assert.assertNotNull(portletSession);
 
 		portletSession.setAttribute("shared", Boolean.TRUE);
 
 		DDMFormDisplayContext createDDMFormDisplayContext =
-			createDDMFormDisplayContext(renderRequest);
+			_createDDMFormDisplayContext(mockRenderRequest);
 
 		Assert.assertTrue(createDDMFormDisplayContext.isFormShared());
 	}
@@ -413,7 +414,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 	public void testIsShowIconInEditMode() throws Exception {
 		_mockHttpServletRequest.addParameter("p_l_mode", Constants.EDIT);
 
-		DDMFormDisplayContext ddmFormDisplayContext = createSpy(
+		DDMFormDisplayContext ddmFormDisplayContext = _createSpy(
 			false, false, false);
 
 		Assert.assertFalse(ddmFormDisplayContext.isShowConfigurationIcon());
@@ -421,7 +422,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Test
 	public void testIsShowIconInPreview() throws Exception {
-		DDMFormDisplayContext ddmFormDisplayContext = createSpy(
+		DDMFormDisplayContext ddmFormDisplayContext = _createSpy(
 			false, true, false);
 
 		Assert.assertFalse(ddmFormDisplayContext.isShowConfigurationIcon());
@@ -429,9 +430,9 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Test
 	public void testIsShowIconWithPermission() throws Exception {
-		mockPortletPermissionUtil();
+		_mockPortletPermissionUtil();
 
-		DDMFormDisplayContext ddmFormDisplayContext = createSpy(
+		DDMFormDisplayContext ddmFormDisplayContext = _createSpy(
 			false, false, true);
 
 		Assert.assertTrue(ddmFormDisplayContext.isShowConfigurationIcon());
@@ -439,7 +440,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Test
 	public void testIsShowIconWithSharedForm() throws Exception {
-		DDMFormDisplayContext ddmFormDisplayContext = createSpy(
+		DDMFormDisplayContext ddmFormDisplayContext = _createSpy(
 			true, false, true);
 
 		Assert.assertFalse(ddmFormDisplayContext.isShowConfigurationIcon());
@@ -447,16 +448,16 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 	@Test
 	public void testIsShowSuccessPage() throws Exception {
-		mockDDMFormInstance(mock(DDMFormInstanceSettings.class));
+		_mockDDMFormInstance(mock(DDMFormInstanceSettings.class));
 
-		MockRenderRequest mockRenderRequest = mockRenderRequest();
+		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
 		SessionMessages.add(
 			mockRenderRequest,
 			SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(mockRenderRequest);
+			_createDDMFormDisplayContext(mockRenderRequest);
 
 		Assert.assertTrue(ddmFormDisplayContext.isShowSuccessPage());
 	}
@@ -472,21 +473,21 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 			"http://localhost:8080/web/forms/shared/-/form/123"
 		);
 
-		mockDDMFormInstance(ddmFormInstanceSettings);
+		_mockDDMFormInstance(ddmFormInstanceSettings);
 
-		MockRenderRequest mockRenderRequest = mockRenderRequest();
+		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
 		SessionMessages.add(
 			mockRenderRequest,
 			SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE);
 
 		DDMFormDisplayContext ddmFormDisplayContext =
-			createDDMFormDisplayContext(mockRenderRequest);
+			_createDDMFormDisplayContext(mockRenderRequest);
 
 		Assert.assertFalse(ddmFormDisplayContext.isShowSuccessPage());
 	}
 
-	protected DDMForm createDDMForm(
+	private DDMForm _createDDMForm(
 		Set<Locale> availableLocales, Locale locale) {
 
 		DDMForm ddmForm = new DDMForm();
@@ -505,13 +506,13 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		return ddmForm;
 	}
 
-	protected DDMFormDisplayContext createDDMFormDisplayContext()
+	private DDMFormDisplayContext _createDDMFormDisplayContext()
 		throws PortalException {
 
-		return createDDMFormDisplayContext(mockRenderRequest());
+		return _createDDMFormDisplayContext(_mockRenderRequest());
 	}
 
-	protected DDMFormDisplayContext createDDMFormDisplayContext(
+	private DDMFormDisplayContext _createDDMFormDisplayContext(
 			RenderRequest renderRequest)
 		throws PortalException {
 
@@ -530,12 +531,12 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 			mock(UserLocalService.class), _workflowDefinitionLinkLocalService);
 	}
 
-	protected DDMFormDisplayContext createSpy(
+	private DDMFormDisplayContext _createSpy(
 			boolean formShared, boolean preview, boolean sharedURL)
-		throws PortalException {
+		throws Exception {
 
 		DDMFormDisplayContext ddmFormDisplayContext = spy(
-			createDDMFormDisplayContext());
+			_createDDMFormDisplayContext());
 
 		Mockito.doReturn(
 			formShared
@@ -558,7 +559,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		return ddmFormDisplayContext;
 	}
 
-	protected DDMFormInstance mockDDMFormInstance() throws PortalException {
+	private DDMFormInstance _mockDDMFormInstance() throws Exception {
 		DDMFormInstance formInstance = mock(DDMFormInstance.class);
 
 		DDMFormInstanceSettings formInstanceSettings = mock(
@@ -573,9 +574,9 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		return formInstance;
 	}
 
-	protected void mockDDMFormInstance(
+	private void _mockDDMFormInstance(
 			DDMFormInstanceSettings ddmFormInstanceSettings)
-		throws PortalException {
+		throws Exception {
 
 		DDMFormInstance ddmFormInstance = mock(DDMFormInstance.class);
 
@@ -585,7 +586,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 			ddmFormInstanceSettings
 		);
 
-		DDMStructure ddmStructure = mockDDMStructure();
+		DDMStructure ddmStructure = _mockDDMStructure();
 
 		when(
 			ddmFormInstance.getStructure()
@@ -600,8 +601,8 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 	}
 
-	protected DDMFormInstanceSettings
-			mockDDMFormInstanceSettingsAutosaveWithNondefaultUser()
+	private DDMFormInstanceSettings
+			_mockDDMFormInstanceSettingsAutosaveWithNondefaultUser()
 		throws Exception {
 
 		DDMFormInstance ddmFormInstance = mock(DDMFormInstance.class);
@@ -624,12 +625,12 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		return ddmFormInstanceSettings;
 	}
 
-	protected DDMStructure mockDDMStructure() throws PortalException {
+	private DDMStructure _mockDDMStructure() throws Exception {
 		DDMStructure ddmStructure = mock(DDMStructure.class);
 
 		Locale defaultLocale = LocaleUtil.fromLanguageId(_DEFAULT_LANGUAGE_ID);
 
-		DDMForm ddmForm = createDDMForm(
+		DDMForm ddmForm = _createDDMForm(
 			new HashSet<>(Arrays.asList(defaultLocale)), defaultLocale);
 
 		when(
@@ -641,7 +642,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		return ddmStructure;
 	}
 
-	protected void mockLanguageGet(String key, String value) {
+	private void _mockLanguageGet(String key, String value) {
 		when(
 			_language.get(Matchers.any(ResourceBundle.class), Matchers.eq(key))
 		).thenReturn(
@@ -649,7 +650,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 	}
 
-	protected void mockPortletPermissionUtil() throws PortalException {
+	private void _mockPortletPermissionUtil() throws Exception {
 		mockStatic(PortletPermissionUtil.class);
 
 		when(
@@ -662,7 +663,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 	}
 
-	protected MockRenderRequest mockRenderRequest() throws PortalException {
+	private MockRenderRequest _mockRenderRequest() throws PortalException {
 		MockRenderRequest mockRenderRequest = new MockRenderRequest();
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
@@ -678,14 +679,14 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		return mockRenderRequest;
 	}
 
-	protected RenderRequest mockRenderRequestAutosaveWithNondefaultUser()
+	private RenderRequest _mockRenderRequestAutosaveWithNondefaultUser()
 		throws Exception {
 
-		MockRenderRequest renderRequest = mockRenderRequest();
+		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
 		ThemeDisplay themeDisplay = mock(ThemeDisplay.class);
 
-		renderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+		mockRenderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
 		User user = mock(User.class);
 
@@ -715,10 +716,10 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 			portletDisplay
 		);
 
-		return renderRequest;
+		return mockRenderRequest;
 	}
 
-	protected void mockWorkflowDefinitionLinkLocalService(
+	private void _mockWorkflowDefinitionLinkLocalService(
 		boolean hasWorkflowDefinitionLink) {
 
 		when(
@@ -730,13 +731,15 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 	}
 
-	protected void setUpJSONFactoryUtil() {
+	private void _setUpJSONFactoryUtil() {
 		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
 
 		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
 	}
 
-	protected void setUpLanguageUtil() {
+	private void _setUpLanguageUtil() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
 		when(
 			_language.getLanguageId(Matchers.any(Locale.class))
 		).thenReturn(
@@ -749,12 +752,10 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 			_DEFAULT_LANGUAGE_ID
 		);
 
-		LanguageUtil languageUtil = new LanguageUtil();
-
 		languageUtil.setLanguage(_language);
 	}
 
-	protected void setUpLocaleUtil() {
+	private void _setUpLocaleUtil() {
 		mockStatic(LocaleUtil.class);
 
 		when(
@@ -770,7 +771,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 	}
 
-	protected void setUpPortalUtil() {
+	private void _setUpPortalUtil() {
 		PortalUtil portalUtil = new PortalUtil();
 
 		portalUtil.setPortal(mock(Portal.class));
@@ -796,7 +797,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 		);
 	}
 
-	protected void setUpResourceBundleUtil() {
+	private void _setUpResourceBundleUtil() {
 		mockStatic(ResourceBundleUtil.class);
 
 		when(


### PR DESCRIPTION
The `StringUtil.contains(themeDisplay.getURLCurrent(), "/shared");` is not returning true if the string contains `/shared`. 

As described [here](https://github.com/liferay/liferay-portal/blob/7adcf670371864a2228cbd2e3bb8edde34f64f77/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java#L236-L259), the `StringUtil.contains` behaves as follows:
```
contains("one,two,three", "thr") returns false
contains("one,two,three", "one,two") returns true
```
