### PR TITLE
LPS-139685 Do not allow submitting an invalid entry in the object relationship field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryHelper.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -114,7 +115,8 @@ public class DDMFormTemplateContextFactoryHelper {
 	}
 
 	protected boolean isDDMFormFieldEvaluable(DDMFormField ddmFormField) {
-		if (GetterUtil.getBoolean(ddmFormField.getProperty("inputMask")) ||
+		if (Objects.equals(ddmFormField.getType(), "object-relationship") ||
+			GetterUtil.getBoolean(ddmFormField.getProperty("inputMask")) ||
 			GetterUtil.getBoolean(
 				ddmFormField.getProperty("requireConfirmation")) ||
 			GetterUtil.getBoolean(ddmFormField.getProperty("required"))) {

--- a/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/form/field/type/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/form/field/type/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
@@ -25,7 +25,6 @@ import com.liferay.object.rest.context.path.RESTContextPathResolverRegistry;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
@@ -111,6 +110,16 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 		DDMFormField ddmFormField,
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
 
+		String apiURL = GetterUtil.getString(
+			ddmFormField.getProperty("apiURL"));
+
+		if (Validator.isNotNull(apiURL)) {
+			return apiURL;
+		}
+
+		apiURL = _portal.getPortalURL(
+			ddmFormFieldRenderingContext.getHttpServletRequest());
+
 		long objectDefinitionId = GetterUtil.getLong(
 			getValue(
 				GetterUtil.getString(
@@ -121,18 +130,8 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 				objectDefinitionId);
 
 		if (objectDefinition == null) {
-			return StringPool.BLANK;
-		}
-
-		String apiURL = GetterUtil.getString(
-			ddmFormField.getProperty("apiURL"));
-
-		if (Validator.isNotNull(apiURL)) {
 			return apiURL;
 		}
-
-		apiURL = _portal.getPortalURL(
-			ddmFormFieldRenderingContext.getHttpServletRequest());
 
 		RESTContextPathResolver restContextPathResolver =
 			_restContextPathResolverRegistry.getRESTContextPathResolver(

--- a/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/form/field/type/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/form/field/type/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
@@ -65,8 +65,6 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 		).put(
 			"initialLabel", ddmFormFieldRenderingContext.getValue()
 		).put(
-			"initialValue", ddmFormFieldRenderingContext.getValue()
-		).put(
 			"inputName", ddmFormField.getName()
 		).put(
 			"labelKey", "id"


### PR DESCRIPTION
- LPS-137749 Remove property to skip virtual instance from PopulateObjectFormsConfiguration#CanSelectObjectStorageType test
- Revert "LPS-139069 Count global group on getGroupsCount"
- LPS-139069 Count global group on getGroupsCount and add isCompany check to the _filterGroups
- LPS-139109 Render fragment as isolated to make sure script are added inline. Otherwise some script may be missing
- LPS-139109 Do not render when it is not necessary. The first time this code is executed previousEditableValues is always undefined, triggering a fragment render
- LPS-137301 Add resources
- LPS-137301 Add corrections
- LPS-137301 Rebase correction
- LPS-137301 Minor changes
- LPS-137301 SF
- LPS-139744 Add CannotCreateDuplicatedFieldName Test
- LPS-139744 SF
- LPS-105380 Add logic to add/remove the emtpy line between the same self-closing tags
- LPS-105380 Auto SF
- LPS-105380 Fix broken testcases
- LPS-105380 Add testcases
- LPS-139037 Add DisplaySpecificEntryLong Test
- LPS-139038 Add DisplaySpecificEntryString Test
- LPS-139033 Add DisplaySpecificEntryBoolean Test
- LPS-139032 Add DisplaySpecificEntryBigDecimal Test
- LPS-139036 Add DisplaySpecificEntryInteger Test
- LPS-139035 Add DisplaySpecificEntryDouble Test
- LPS-139037 SF
- LRCI-2462 Fix regex replacement for poshi screenshots
- LRCI-2462 prep next
- LPS-135850 Support both old style and new nested DDM fields
- LPS-139169 Apply the same solution from 532551ce365510dbbab8575489e8d8513fa4f940 to the LiferaySerializer class
- LPS-139169 Add test
- LPS-139880 Replace Source Formatter Ignore for Supress
- LPS-139880 Ignore Lines
- LPS-139880 Get Values from Custom Object Attribute
- LPS-139685 Fix dropdown behavior
- LPS-139685 Make object relationship field evaluable
- LPS-139685 Set value to null if user is still searching
- LPS-139685 Validate Object Relationship field
