### PR TITLE
LPS-139008 

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/object/ObjectFieldDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/object/ObjectFieldDDMFormFieldTemplateContextContributor.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.field.type.internal.object;
+
+import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTemplateContextContributor;
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Carolina Barbosa
+ */
+@Component(
+	immediate = true,
+	property = "ddm.form.field.type.name=" + DDMFormFieldTypeConstants.OBJECT_FIELD,
+	service = {
+		DDMFormFieldTemplateContextContributor.class,
+		ObjectFieldDDMFormFieldTemplateContextContributor.class
+	}
+)
+public class ObjectFieldDDMFormFieldTemplateContextContributor
+	implements DDMFormFieldTemplateContextContributor {
+
+	@Override
+	public Map<String, Object> getParameters(
+		DDMFormField ddmFormField,
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		return HashMapBuilder.<String, Object>put(
+			"objectDefinitionId",
+			_getObjectDefinitionId(ddmFormField, ddmFormFieldRenderingContext)
+		).build();
+	}
+
+	private String _getObjectDefinitionId(
+		DDMFormField ddmFormField,
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		Map<String, Object> changedProperties =
+			(Map<String, Object>)ddmFormFieldRenderingContext.getProperty(
+				"changedProperties");
+
+		if (MapUtil.isNotEmpty(changedProperties)) {
+			Object objectDefinitionId = changedProperties.get(
+				"objectDefinitionId");
+
+			if (objectDefinitionId instanceof JSONArray) {
+				JSONArray jsonArray = (JSONArray)objectDefinitionId;
+
+				return GetterUtil.getString(jsonArray.get(0));
+			}
+		}
+
+		return _getValue(
+			GetterUtil.getString(
+				ddmFormField.getProperty("objectDefinitionId")));
+	}
+
+	private String _getValue(String value) {
+		try {
+			JSONArray jsonArray = _jsonFactory.createJSONArray(value);
+
+			return GetterUtil.getString(jsonArray.get(0));
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonException, jsonException);
+			}
+
+			return value;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectFieldDDMFormFieldTemplateContextContributor.class);
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ObjectField/ObjectField.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ObjectField/ObjectField.js
@@ -12,13 +12,16 @@
  * details.
  */
 
+import {useResource} from '@clayui/data-provider';
+import {usePrevious} from '@liferay/frontend-js-react-web';
 import {useFormState} from 'data-engine-js-components-web';
 import {getFields} from 'data-engine-js-components-web/js/utils/fields.es';
 import {
 	getObjectFieldName,
 	getSelectedValue,
 } from 'data-engine-js-components-web/js/utils/objectFields';
-import React, {useMemo} from 'react';
+import {fetch} from 'frontend-js-web';
+import React, {useEffect, useMemo} from 'react';
 
 import Select from '../Select/Select.es';
 
@@ -136,10 +139,71 @@ const ObjectField = ({
 	);
 };
 
-const ObjectFieldWrapper = (props) => {
+const ObjectDefinitionObjectField = ({
+	label,
+	objectDefinitionId,
+	onChange,
+	readOnly,
+	spritemap,
+	value = {},
+	visible,
+}) => {
+	const {refetch, resource} = useResource({
+		fetch,
+		fetchPolicy: 'cache-first',
+		link: `${window.location.origin}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}`,
+	});
+
+	const previousObjectDefinitionId = usePrevious(objectDefinitionId);
+
+	useEffect(() => {
+		if (
+			objectDefinitionId &&
+			objectDefinitionId !== previousObjectDefinitionId
+		) {
+			refetch();
+		}
+	}, [objectDefinitionId, previousObjectDefinitionId, refetch]);
+
+	const options =
+		resource?.objectFields?.map(({label, name}) => {
+			return {
+				label:
+					label[
+						formatLanguageId(themeDisplay.getDefaultLanguageId())
+					] ?? name,
+				value: name,
+			};
+		}) || [];
+
+	return (
+		<Select
+			label={label}
+			name="selectedObjectField"
+			onChange={onChange}
+			options={options}
+			readOnly={readOnly}
+			showEmptyOption={!!options.length}
+			spritemap={spritemap}
+			value={value}
+			visible={visible}
+		/>
+	);
+};
+
+const ObjectFieldWrapper = ({objectDefinitionId, ...props}) => {
 	const {objectFields} = useFormState();
 
 	if (!objectFields?.length) {
+		if (objectDefinitionId) {
+			return (
+				<ObjectDefinitionObjectField
+					objectDefinitionId={objectDefinitionId}
+					{...props}
+				/>
+			);
+		}
+
 		return null;
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/settings/AddObjectEntryObjectActionSettings.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/settings/AddObjectEntryObjectActionSettings.java
@@ -16,11 +16,32 @@ package com.liferay.object.internal.action.settings;
 
 import com.liferay.dynamic.data.mapping.annotations.DDMForm;
 import com.liferay.dynamic.data.mapping.annotations.DDMFormField;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutColumn;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutPage;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutRow;
 
 /**
  * @author Marco Leo
  */
 @DDMForm
+@DDMFormLayout(
+	paginationMode = com.liferay.dynamic.data.mapping.model.DDMFormLayout.SINGLE_PAGE_MODE,
+	value = {
+		@DDMFormLayoutPage(
+			{
+				@DDMFormLayoutRow(
+					{
+						@DDMFormLayoutColumn(
+							size = 12,
+							value = {"objectDefinitionId", "objectFieldName"}
+						)
+					}
+				)
+			}
+		)
+	}
+)
 public interface AddObjectEntryObjectActionSettings {
 
 	@DDMFormField(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/settings/AddObjectEntryObjectActionSettings.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/settings/AddObjectEntryObjectActionSettings.java
@@ -20,11 +20,19 @@ import com.liferay.dynamic.data.mapping.annotations.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutColumn;
 import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutPage;
 import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutRow;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormRule;
 
 /**
  * @author Marco Leo
  */
-@DDMForm
+@DDMForm(
+	rules = {
+		@DDMFormRule(
+			actions = "setPropertyValue('objectFieldName', 'objectDefinitionId', getValue('objectDefinitionId'))",
+			condition = "TRUE"
+		)
+	}
+)
 @DDMFormLayout(
 	paginationMode = com.liferay.dynamic.data.mapping.model.DDMFormLayout.SINGLE_PAGE_MODE,
 	value = {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/settings/WebhookObjectActionSettings.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/settings/WebhookObjectActionSettings.java
@@ -16,11 +16,27 @@ package com.liferay.object.internal.action.settings;
 
 import com.liferay.dynamic.data.mapping.annotations.DDMForm;
 import com.liferay.dynamic.data.mapping.annotations.DDMFormField;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutColumn;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutPage;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutRow;
 
 /**
  * @author Marco Leo
  */
 @DDMForm
+@DDMFormLayout(
+	paginationMode = com.liferay.dynamic.data.mapping.model.DDMFormLayout.SINGLE_PAGE_MODE,
+	value = {
+		@DDMFormLayoutPage(
+			{
+				@DDMFormLayoutRow(
+					{@DDMFormLayoutColumn(size = 12, value = {"url", "secret"})}
+				)
+			}
+		)
+	}
+)
 public interface WebhookObjectActionSettings {
 
 	@DDMFormField(label = "secret")

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.web.internal.object.definitions.display.context;
 
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingContext;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingException;
@@ -46,6 +47,7 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.taglib.servlet.PipingServletResponseFactory;
@@ -313,7 +315,10 @@ public class ObjectDefinitionsActionsDisplayContext {
 					}
 					else {
 						ddmFormFieldValue.setValue(
-							new UnlocalizedValue(String.valueOf(serializable)));
+							new UnlocalizedValue(
+								_getValue(
+									ddmFormField.getType(),
+									String.valueOf(serializable))));
 					}
 
 					return ddmFormFieldValue;
@@ -322,6 +327,18 @@ public class ObjectDefinitionsActionsDisplayContext {
 		ddmFormValues.setDefaultLocale(_objectRequestHelper.getLocale());
 
 		return ddmFormValues;
+	}
+
+	private String _getValue(String type, String value) {
+		if (StringUtil.equals(type, DDMFormFieldTypeConstants.OBJECT_FIELD) ||
+			StringUtil.equals(type, DDMFormFieldTypeConstants.SELECT)) {
+
+			return JSONUtil.putAll(
+				StringUtil.split(value)
+			).toString();
+		}
+
+		return value;
 	}
 
 	private boolean _hasAddObjectActionPermission() throws Exception {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
@@ -19,10 +19,12 @@ import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingContext;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingException;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.DDMFormFactory;
+import com.liferay.dynamic.data.mapping.util.DDMFormLayoutFactory;
 import com.liferay.frontend.taglib.clay.data.set.servlet.taglib.util.ClayDataSetActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.action.executor.ObjectActionExecutor;
@@ -241,6 +243,9 @@ public class ObjectDefinitionsActionsDisplayContext {
 		DDMForm ddmForm = DDMFormFactory.create(
 			objectActionExecutor.getSettings());
 
+		DDMFormLayout ddmFormLayout = DDMFormLayoutFactory.create(
+			objectActionExecutor.getSettings());
+
 		DDMFormRenderingContext ddmFormRenderingContext =
 			new DDMFormRenderingContext();
 
@@ -269,7 +274,8 @@ public class ObjectDefinitionsActionsDisplayContext {
 
 		ddmFormRenderingContext.setShowRequiredFieldsWarning(true);
 
-		return _ddmFormRenderer.render(ddmForm, ddmFormRenderingContext);
+		return _ddmFormRenderer.render(
+			ddmForm, ddmFormLayout, ddmFormRenderingContext);
 	}
 
 	private DDMFormValues _getDDMFormValues(

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_action.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_action.jsp
@@ -74,10 +74,36 @@ ObjectAction objectAction = objectDefinitionsActionsDisplayContext.getObjectActi
 
 			const fields = current.getFields();
 
-			values = fields.reduce(
-				(obj, cur) => Object.assign(obj, {[cur.fieldName]: cur.value}),
-				{}
-			);
+			values = fields
+				.map((field) => {
+					const {fieldName, type, value} = field;
+
+					if (type === 'object_field' || type === 'select') {
+						let newValue = value;
+
+						if (newValue && typeof newValue === 'string') {
+							try {
+								newValue = JSON.parse(newValue);
+							}
+							catch (error) {}
+						}
+
+						if (Array.isArray(newValue)) {
+							newValue = newValue[0];
+						}
+
+						return {
+							fieldName,
+							value: newValue,
+						};
+					}
+
+					return field;
+				})
+				.reduce(
+					(obj, cur) => Object.assign(obj, {[cur.fieldName]: cur.value}),
+					{}
+				);
 		}
 
 		Liferay.Util.fetch(


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-139008

- LPS-139008 Add DDMFormLayout to Object Action Settings
- LPS-139008 Create DDMFormRule to set the ObjectDefinitionId property on the ObjectFieldName field
- LPS-139008 Create DDMFormFieldTemplateContextContributor to send the updated ObjectDefinitionId property to the component
- LPS-139008 Receive the ObjectDefinitionId property and render the right component
- LPS-139008 When the field type is Select or ObjectField, the value must be saved as String
