### PR TITLE
LPS-140084 It is not possible to add special characters on a String type field that has a Field Name called name

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DDMFormFieldTypeSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DDMFormFieldTypeSettings.java
@@ -55,14 +55,18 @@ public interface DDMFormFieldTypeSettings {
 
 	@DDMFormField(
 		label = "%field-reference",
-		properties = "tooltip=%field-reference-serves-as-a-frienldy-identifier"
+		properties = {
+			"normalizeField=true",
+			"tooltip=%field-reference-serves-as-a-frienldy-identifier"
+		}
 	)
 	public default String fieldReference() {
 		return StringPool.BLANK;
 	}
 
 	@DDMFormField(
-		label = "%field-name", required = true, visibilityExpression = "FALSE"
+		label = "%field-name", properties = "normalizeField=true",
+		required = true, visibilityExpression = "FALSE"
 	)
 	public String name();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTypeSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTypeSettings.java
@@ -176,6 +176,7 @@ public interface NumericDDMFormFieldTypeSettings
 	@DDMFormField(
 		dataType = "string", label = "%format",
 		properties = {
+			"invalidCharacters=[1-8]",
 			"placeholder=%input-mask-format-placeholder",
 			"tooltip=%an-input-mask-helps-to-ensure-a-predefined-format"
 		},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/text/TextDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/text/TextDDMFormFieldTemplateContextContributor.java
@@ -91,6 +91,12 @@ public class TextDDMFormFieldTemplateContextContributor
 		}
 
 		return HashMapBuilder.<String, Object>put(
+			"invalidCharacters",
+			GetterUtil.getString(ddmFormField.getProperty("invalidCharacters"))
+		).put(
+			"normalizeField",
+			GetterUtil.getBoolean(ddmFormField.getProperty("normalizeField"))
+		).put(
 			"options", getOptions(ddmFormField, ddmFormFieldRenderingContext)
 		).put(
 			"predefinedValue",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -29,10 +29,12 @@ const Text = ({
 	editingLanguageId,
 	fieldName,
 	id,
+	invalidCharacters,
 	localizable,
 	localizedValue,
 	maxLength,
 	name,
+	normalizeField,
 	onBlur,
 	onChange,
 	onFocus,
@@ -70,7 +72,7 @@ const Text = ({
 
 	useEffect(() => {
 		if (
-			fieldName === 'fieldReference' &&
+			normalizeField &&
 			inputRef.current &&
 			inputRef.current.value !== initialValue &&
 			(inputRef.current.value === '' || shouldUpdateValue)
@@ -82,6 +84,7 @@ const Text = ({
 		initialValue,
 		inputRef,
 		fieldName,
+		normalizeField,
 		onChange,
 		setValue,
 		shouldUpdateValue,
@@ -98,7 +101,7 @@ const Text = ({
 			maxLength={maxLength}
 			name={name}
 			onBlur={(event) => {
-				if (fieldName == 'fieldReference') {
+				if (normalizeField) {
 					onBlur({target: {value: initialValue}});
 				}
 				else {
@@ -108,11 +111,13 @@ const Text = ({
 			onChange={(event) => {
 				const {value} = event.target;
 
-				if (fieldName === 'fieldReference' || fieldName === 'name') {
+				if (normalizeField) {
 					event.target.value = normalizeFieldName(value);
 				}
-				else if (fieldName === 'inputMaskFormat') {
-					event.target.value = value.replace(/[1-8]/g, '');
+				else if (invalidCharacters) {
+					const regex = new RegExp(invalidCharacters, 'g');
+
+					event.target.value = value.replace(regex, '');
 				}
 
 				setValue(event.target.value);
@@ -346,11 +351,13 @@ const Main = ({
 	displayStyle = 'singleline',
 	fieldName,
 	id,
+	invalidCharacters = '',
 	locale,
 	localizable,
 	localizedValue = {},
 	maxLength,
 	name,
+	normalizeField = false,
 	onBlur,
 	onChange,
 	onFocus,
@@ -390,10 +397,12 @@ const Main = ({
 				editingLanguageId={locale}
 				fieldName={fieldName}
 				id={fieldDetailsId}
+				invalidCharacters={invalidCharacters}
 				localizable={localizable}
 				localizedValue={localizedValue}
 				maxLength={maxLength}
 				name={name}
+				normalizeField={normalizeField}
 				onBlur={onBlur}
 				onChange={onChange}
 				onFocus={onFocus}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTypeSettingsTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTypeSettingsTest.java
@@ -149,6 +149,8 @@ public class NumericDDMFormFieldTypeSettingsTest
 		Assert.assertTrue(inputMaskFormatDDMFormField.isRequired());
 		Assert.assertNotNull(inputMaskFormatDDMFormField.getLabel());
 		Assert.assertNotNull(
+			inputMaskFormatDDMFormField.getProperty("invalidCharacters"));
+		Assert.assertNotNull(
 			inputMaskFormatDDMFormField.getProperty("placeholder"));
 		Assert.assertNotNull(
 			inputMaskFormatDDMFormField.getProperty("tooltip"));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/text/TextDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/text/TextDDMFormFieldTemplateContextContributorTest.java
@@ -72,6 +72,8 @@ public class TextDDMFormFieldTemplateContextContributorTest
 
 		Assert.assertTrue(parameters.containsKey("autocompleteEnabled"));
 		Assert.assertTrue(parameters.containsKey("displayStyle"));
+		Assert.assertTrue(parameters.containsKey("invalidCharacters"));
+		Assert.assertTrue(parameters.containsKey("normalizeField"));
 		Assert.assertTrue(parameters.containsKey("placeholder"));
 		Assert.assertTrue(parameters.containsKey("tooltip"));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/Text.es.js
@@ -361,14 +361,14 @@ describe('Field Text', () => {
 		expect(onChange).toHaveBeenCalled();
 	});
 
-	it('normalizes the field reference if it contains invalid characters', () => {
+	it('normalizes the field if it contains invalid characters', () => {
 		const onChange = jest.fn();
 
 		const {container} = render(
 			<TextWithProvider
 				{...defaultTextConfig}
-				fieldName="fieldReference"
 				key="input"
+				normalizeField={true}
 				onChange={onChange}
 			/>
 		);
@@ -388,13 +388,13 @@ describe('Field Text', () => {
 		expect(input.value).toEqual('FieldReference');
 	});
 
-	it('normalizes the value of the Format field if it contains invalid characters', () => {
+	it('normalizes the value of the field if it contains invalid characters', () => {
 		const onChange = jest.fn();
 
 		const {container} = render(
 			<TextWithProvider
 				{...defaultTextConfig}
-				fieldName="inputMaskFormat"
+				invalidCharacters="[1-8]"
 				key="input"
 				onChange={onChange}
 			/>


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-140084

- LPS-140084 Define properties instead of using the fieldName
- LPS-140084 Fix tests
- LPS-140084 Increment tests
